### PR TITLE
Add support for variables, "+" and "#"

### DIFF
--- a/pkg/mqtt/topic.go
+++ b/pkg/mqtt/topic.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -96,4 +97,11 @@ func (tm *TopicMap) Store(t *Topic) {
 // Delete deletes the topic for the given key.
 func (tm *TopicMap) Delete(key string) {
 	tm.Map.Delete(key)
+}
+
+// replace all __PLUS__ with + and one __HASH__ with #
+// Question: Why does grafana not allow + and # in query?
+func resolveTopic(topic string) string {
+	resolvedTopic := strings.ReplaceAll(topic, "__PLUS__", "+")
+	return strings.Replace(resolvedTopic, "__HASH__", "#", -1)
 }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -8,9 +8,12 @@ export class DataSource extends DataSourceWithBackend<MqttQuery, MqttDataSourceO
   }
 
   applyTemplateVariables(query: MqttQuery, scopedVars: ScopedVars): Record<string, any> {
+    let resolvedTopic = getTemplateSrv().replace(query.topic, scopedVars);
+    resolvedTopic = resolvedTopic.replace(/\+/gi, '__PLUS__');
+    resolvedTopic = resolvedTopic.replace(/\#/gi, '__HASH__');
     const resolvedQuery: MqttQuery = {
       ...query,
-      topic: getTemplateSrv().replace(query.topic, scopedVars),
+      topic: resolvedTopic,
     };
 
     return resolvedQuery;

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,9 +1,18 @@
-import { DataSourceInstanceSettings } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { MqttDataSourceOptions, MqttQuery } from './types';
 
 export class DataSource extends DataSourceWithBackend<MqttQuery, MqttDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<MqttDataSourceOptions>) {
     super(instanceSettings);
+  }
+
+  applyTemplateVariables(query: MqttQuery, scopedVars: ScopedVars): Record<string, any> {
+    const resolvedQuery: MqttQuery = {
+      ...query,
+      topic: getTemplateSrv().replace(query.topic, scopedVars),
+    };
+
+    return resolvedQuery;
   }
 }


### PR DESCRIPTION
This PR adds support for
- variable support via overwriting the `applyTemplateVariable` function of the class `DataSource`.
  - Now topics can contain variables. E.g.: `tlm/${Device}/measurement` 
  - Single selection and all selection for repeating panels works
- `+` operator of mqtt
  - e.g. `tlm/+/measurement` or `tlm/+/measurement/+` 
- `#` operator of mqtt
  - e.g. `tlm/device1/#`  
