### PR TITLE
Fix clear field data

### DIFF
--- a/pkg/mqtt/framer.go
+++ b/pkg/mqtt/framer.go
@@ -99,7 +99,7 @@ func newFramer() *framer {
 func (df *framer) toFrame(messages []Message) (*data.Frame, error) {
 	// clear the data in the fields
 	for _, field := range df.fields {
-		for i := 0; i < field.Len(); i++ {
+		for i := field.Len() - 1; i >= 0; i-- {
 			field.Delete(i)
 		}
 	}


### PR DESCRIPTION
Channel messages contain duplicated values, because fields form the previous message wasn't cleared entirely (only half of the slice).