### PR TITLE
chore: pin yarn version in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "react-dom": "18.3.1"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=24",
+    "yarn": ">=4.15.0"
   },
   "packageManager": "yarn@4.15.0"
 }


### PR DESCRIPTION
## Summary
- Adds `"yarn": ">=4.15.0"` to the `engines` field in `package.json` to pin the required yarn version.

## Test plan
- [ ] Verify `package.json` engines field contains both `node` and `yarn` constraints