### PR TITLE
update github workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -7,22 +7,20 @@ on:
     types:
       - opened
 
-permissions: {}
-
 jobs:
   add-to-project:
-    name: Add issue to project
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+    name: Add issue to project
+    runs-on: ubuntu-latest
     steps:
       - id: get-github-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: grafana-oss-big-tent
       - name: Add to project
-        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        uses: actions/add-to-project@8b5d8dd2895c251002b427e4688a6115b5ed2f09 # main
         with:
-          project-url: https://github.com/orgs/grafana/projects/1085
+          project-url: https://github.com/orgs/grafana/projects/1085 # Grafana Data Source Plugins Squad 🐴
           github-token: ${{ steps.get-github-token.outputs.token }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     types:
       - opened
-permissions: {}
 
 jobs:
   add-to-project:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types:
       - opened
+permissions: {}
 
 jobs:
   add-to-project:

--- a/.github/workflows/update-create-plugin.yml
+++ b/.github/workflows/update-create-plugin.yml
@@ -17,6 +17,6 @@ jobs:
         uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: grafana-oss-big-tent
-      - uses: grafana/plugin-actions/create-plugin-update@244c3bc9c6eb94bc1dd6458ade2462499bbf0f5b #create-plugin-update/v2.0.1
+      - uses: grafana/plugin-actions/create-plugin-update@b82357e85d512c678416146ca4e9f8672bd108da #create-plugin-update/v2.0.2
         with:
           token: ${{ steps.get-github-token.outputs.token }}

--- a/.github/workflows/update-create-plugin.yml
+++ b/.github/workflows/update-create-plugin.yml
@@ -5,20 +5,18 @@ on:
   schedule:
     - cron: '0 0 1 * *' # run once a month on the 1st day
 
-permissions: {}
-
 jobs:
   release:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write # Needed for create-github-app-token
       pull-requests: write
+    runs-on: ubuntu-latest
     steps:
       - id: get-github-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: grafana-oss-big-tent
-      - uses: grafana/plugin-actions/create-plugin-update@b82357e85d512c678416146ca4e9f8672bd108da #create-plugin-update/v2.0.2
+      - uses: grafana/plugin-actions/create-plugin-update@244c3bc9c6eb94bc1dd6458ade2462499bbf0f5b #create-plugin-update/v2.0.1
         with:
           token: ${{ steps.get-github-token.outputs.token }}


### PR DESCRIPTION
Updates the repos github workflows:

- `add-to-project` to use latest versions for get-github-token and add-to-project parent.

- `update-create-plugin` to use latest version for get-github-token