### PR TITLE
fix(security): bump out-of-SLO react-router to 6.30.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
     "node": ">=24",
     "yarn": ">=4.15.0"
   },
+  "resolutions": {
+    "react-router@npm:6.30.3": "6.30.4"
+  },
   "packageManager": "yarn@4.17.1"
 }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "yarn": ">=4.15.0"
   },
   "resolutions": {
-    "react-router@npm:6.30.3": "6.30.4"
+    "react-router@npm:6.30.3": "6.30.4",
+    "@remix-run/router": "1.23.3"
   },
   "packageManager": "yarn@4.17.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3676,6 +3676,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@remix-run/router@npm:1.23.3":
+  version: 1.23.3
+  resolution: "@remix-run/router@npm:1.23.3"
+  checksum: 10c0/73622465dd9e9a2c5a7ced7d1151ea6e9195a8a979c99b4f70a67093eeff7f339daf03a7c6304709a9c27deb2081a8fff6737663aacb33529c1a12a0a0827a17
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.34.0":
   version: 0.34.49
   resolution: "@sinclair/typebox@npm:0.34.49"
@@ -11328,7 +11335,7 @@ __metadata:
   dependencies:
     "@remix-run/router": "npm:1.23.2"
     history: "npm:^5.3.0"
-    react-router: "npm:6.30.3"
+    react-router: "npm:6.30.4"
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
@@ -11373,14 +11380,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:6.30.3":
-  version: 6.30.3
-  resolution: "react-router@npm:6.30.3"
+"react-router@npm:6.30.4":
+  version: 6.30.4
+  resolution: "react-router@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.2"
+    "@remix-run/router": "npm:1.23.3"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/a0a74bf5a933cf0abd47e0eac1d3a505cd66b866e3ee8f20d8016885d3b4361ba3ba72dee026248c6125e631b191ba6ad109184c892281cea6cb747c71bf5940
+  checksum: 10c0/fb6de7d1002bcab9ea12c4072d93792eca494f1e4f30cfec334ccb6523756d23ce3e093c7c1241399296cebed94789a3fb89f96ee76004e0e746458a8f6bab33
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11335,7 +11335,7 @@ __metadata:
   dependencies:
     "@remix-run/router": "npm:1.23.2"
     history: "npm:^5.3.0"
-    react-router: "npm:6.30.4"
+    react-router: "npm:6.30.3"
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3669,13 +3669,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.2":
-  version: 1.23.2
-  resolution: "@remix-run/router@npm:1.23.2"
-  checksum: 10c0/7096b7f2086b2cd80c9e06873b71a8317e04858c01edc06a6fed187b660408a90f47c8e120e8af4c369cf1fa6b6a316a66b0917f42b6eb8a566e98b277c50449
-  languageName: node
-  linkType: hard
-
 "@remix-run/router@npm:1.23.3":
   version: 1.23.3
   resolution: "@remix-run/router@npm:1.23.3"


### PR DESCRIPTION
- Pin out-of-SLO transitive `react-router` 6.30.3 → 6.30.4 (CVE-2026-40181)
- Selective resolution keeps `react-router@5.3.4` untouched
- Checks: typecheck + test:ci (11) pass