### PR TITLE
Prepare release 1.3.6

### DIFF
--- a/.changeset/good-crabs-smile.md
+++ b/.changeset/good-crabs-smile.md
@@ -1,5 +1,0 @@
----
-'grafana-mqtt-datasource': patch
----
-
-Update contributing document

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.6
+
+🐛 Security: bump out-of-SLO react-router to 6.30.4
+
+⚙️ Updated frontend & backend dependencies
+
+📝 Docs: Update contributing document
+
 ## 1.3.5
 
 ⚙️ Updated frontend & backend dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-mqtt-datasource",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "MQTT Datasource Plugin",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
- Bump version to `1.3.6` in `package.json`
- Update `CHANGELOG.md` with changes since [v1.3.5](https://github.com/grafana/mqtt-datasource/releases/tag/v1.3.5) (released 2026-07-22)
- Checks: spellcheck pass; merge then run Plugins CI CD per CONTRIBUTING