### PR TITLE
fix(mqtt): resubscribe on refresh to deliver retained messages

### DIFF
--- a/pkg/mqtt/client.go
+++ b/pkg/mqtt/client.go
@@ -21,6 +21,9 @@ type Client interface {
 	Subscribe(string, log.Logger) (*Topic, error)
 	Unsubscribe(string, log.Logger) error
 	Dispose()
+	// Resubscribe unsubscribes and re-subscribes to force retained message delivery.
+	// Used on dashboard refresh to ensure retained messages are resent.
+	Resubscribe(string, log.Logger) (*Topic, error)
 }
 
 type Options struct {
@@ -195,6 +198,19 @@ func (c *client) Unsubscribe(reqPath string, logger log.Logger) error {
 	}
 
 	return nil
+}
+
+// Resubscribe unsubscribes from the topic and re-subscribes to force
+// the MQTT broker to resend retained messages. This is needed when a
+// dashboard is refreshed and the old stream's messages were cleared.
+func (c *client) Resubscribe(reqPath string, logger log.Logger) (*Topic, error) {
+	// Unsubscribe first to clear the old subscription
+	if err := c.Unsubscribe(reqPath, logger); err != nil {
+		return nil, err
+	}
+	// Now subscribe again - this will create a new subscription
+	// and the broker will resend retained messages
+	return c.Subscribe(reqPath, logger)
 }
 
 func (c *client) Dispose() {

--- a/pkg/mqtt/client_test.go
+++ b/pkg/mqtt/client_test.go
@@ -63,6 +63,13 @@ func (m *mockClient) Unsubscribe(reqPath string, logger log.Logger) error {
 	return nil
 }
 
+func (m *mockClient) Resubscribe(reqPath string, logger log.Logger) (*Topic, error) {
+	// Unsubscribe first
+	m.topics.Delete(reqPath)
+	// Then re-subscribe (calls Subscribe which handles the full logic)
+	return m.Subscribe(reqPath, logger)
+}
+
 func (m *mockClient) Dispose() {
 	// Clear all topics and subscriptions
 	m.topics = TopicMap{}
@@ -307,5 +314,47 @@ func TestClient_MessageHandling_WithStreamingKeys(t *testing.T) {
 	}
 	if len(updatedTopic2.Messages) != 0 {
 		t.Errorf("Expected 0 messages in topic2, got %d", len(updatedTopic2.Messages))
+	}
+}
+
+func TestClient_Resubscribe(t *testing.T) {
+	c := newMockClient()
+
+	reqPath := "1s/dGVzdC90b3BpYw/user1/hash123/org456"
+
+	// Subscribe first time
+	topic1, err := c.Subscribe(reqPath, log.DefaultLogger)
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+	if topic1 == nil {
+		t.Fatal("Expected topic to be created")
+	}
+
+	// Add a message to verify old topic state
+	c.HandleMessage("dGVzdC90b3BpYw/user1/hash123/org456", []byte("old message"))
+	updatedTopic1, _ := c.GetTopic(reqPath)
+	if len(updatedTopic1.Messages) != 1 {
+		t.Errorf("Expected 1 message before resubscribe, got %d", len(updatedTopic1.Messages))
+	}
+
+	// Resubscribe should create a new topic (unsubscribes first, then subscribes)
+	topic2, err := c.Resubscribe(reqPath, log.DefaultLogger)
+	if err != nil {
+		t.Fatalf("Resubscribe failed: %v", err)
+	}
+	if topic2 == nil {
+		t.Fatal("Expected topic to be returned after resubscribe")
+	}
+
+	// Verify the new topic is different (messages should be cleared)
+	updatedTopic2, _ := c.GetTopic(reqPath)
+	if len(updatedTopic2.Messages) != 0 {
+		t.Errorf("Expected 0 messages after resubscribe (new subscription), got %d", len(updatedTopic2.Messages))
+	}
+
+	// Verify the new topic is a different instance
+	if topic1 == topic2 {
+		t.Error("Expected different topic instance after resubscribe")
 	}
 }

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -55,4 +55,5 @@ func (c *fakeMQTTClient) IsConnected() bool {
 
 func (c *fakeMQTTClient) Subscribe(_ string, _ log.Logger) (*mqtt.Topic, error) { return nil, nil }
 func (c *fakeMQTTClient) Unsubscribe(_ string, _ log.Logger) error              { return nil }
+func (c *fakeMQTTClient) Resubscribe(_ string, _ log.Logger) (*mqtt.Topic, error) { return nil, nil }
 func (c *fakeMQTTClient) Dispose()                                              {}

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -29,9 +29,19 @@ func (ds *MQTTDatasource) RunStream(ctx context.Context, req *backend.RunStreamR
 		return backend.DownstreamErrorf("invalid interval: %s", chunks[0])
 	}
 
-	_, err = ds.Client.Subscribe(topicKey, logger)
-	if err != nil {
-		return err
+	// Check if this topic already has an active subscription.
+	// If so, force a resubscription to ensure retained messages are resent.
+	// This fixes issue #107/#36 where dashboard refresh loses retained messages.
+	if _, ok := ds.Client.GetTopic(topicKey); ok && ds.Client.IsConnected() {
+		logger.Debug("Resubscribing to force retained message delivery", "topicKey", topicKey)
+		if _, err := ds.Client.Resubscribe(topicKey, logger); err != nil {
+			return err
+		}
+	} else {
+		_, err = ds.Client.Subscribe(topicKey, logger)
+		if err != nil {
+			return err
+		}
 	}
 	defer func() {
 		if unsubErr := ds.Client.Unsubscribe(topicKey, logger); unsubErr != nil {


### PR DESCRIPTION
## Problem

When a Grafana dashboard is refreshed, the MQTT datasource reconnects but doesn't re-subscribe to topics. This causes:

1. **Issue #107**: Data not received after dashboard reload - retained messages are lost because the MQTT client doesn't re-establish the subscription
2. **Issue #36**: Retained MQTT messages not received upon panel refresh - same root cause
3. **Issue #146**: Empty rows when using `context.grafana.locationService.reload()` - messages are cleared but retained messages aren't resent

The root cause is in `RunStream`: when a stream reconnects, it checks if the topic already exists in the TopicMap and returns early without re-subscribing to the MQTT broker. Since MQTT only sends retained messages on new subscriptions (not on reconnects), the dashboard shows empty data.

## Fix

Added a `Resubscribe` method to the `Client` interface that:
1. Unsubscribes from the topic
2. Re-subscribes to the topic

This forces the MQTT broker to resend retained messages, ensuring data is available after dashboard refresh.

In `RunStream`, we now check if a topic already exists and the client is connected. If so, we call `Resubscribe` instead of `Subscribe` to force a fresh subscription.

## Changes

- `pkg/mqtt/client.go`: Added `Resubscribe` method to the `Client` interface and implementation
- `pkg/plugin/stream.go`: Use `Resubscribe` when topic already exists on stream reconnect
- `pkg/mqtt/client_test.go`: Added test for `Resubscribe` behavior
- `pkg/plugin/datasource_test.go`: Added `Resubscribe` stub to fake client

## Testing

All existing tests pass. New test `TestClient_Resubscribe` verifies:
- Resubscribe creates a new topic instance
- Messages are cleared after resubscribe
- The old topic is removed and a new one is created

